### PR TITLE
Fix for March Update

### DIFF
--- a/MiniBase/MiniBase.csproj
+++ b/MiniBase/MiniBase.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MiniBase/MiniBase.csproj
+++ b/MiniBase/MiniBase.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <ProjectGuid>{F4FF2774-AD08-4369-AA33-B0611B8AA06E}</ProjectGuid>
@@ -8,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MiniBase</RootNamespace>
     <AssemblyName>MiniBase</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,8 +54,8 @@
       <HintPath>../lib/Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="PLib, Version=4.19.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PLib.4.19.0\lib\net471\PLib.dll</HintPath>
+    <Reference Include="PLib, Version=4.22.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\PLib.4.22.0\lib\net471\PLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/MiniBase/mod_info.yaml
+++ b/MiniBase/mod_info.yaml
@@ -1,4 +1,4 @@
 supportedContent: VANILLA_ID,EXPANSION1_ID
-minimumSupportedBuild: 644960
-version: 1.2.4
+minimumSupportedBuild: 722606
+version: 1.2.5
 APIVersion: 2

--- a/MiniBase/packages.config
+++ b/MiniBase/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="ILRepack.Lib.MSBuild.Task" version="2.0.44.1" targetFramework="net471" developmentDependency="true" />
   <package id="Microsoft.NETFramework.ReferenceAssemblies.net471" version="1.0.3" targetFramework="net471" developmentDependency="true" />
-  <package id="PLib" version="4.19.0" targetFramework="net471" />
+  <package id="PLib" version="4.22.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Previously, as pointed out in https://github.com/isam2k/MiniBaseSO/issues/15, clicking the options would cause oni to crash. I saw there was a newer version, so I modified the files to use that new version and rebuilt and it worked. 🎉 

I also had to update .net from 4.7.1 to 4.8.

All that said, I know nothing about C# package dependency (or in general really). But I did experiment a bit with modding oni. It seems weird to me that the packages say `net471` still. I thought maybe they should say 480? But this is probably because I directly changed the text instead of doing it with some cool visual studio feature that I don't know about lol. Let me know if there is something I need to do and I can adjust.

Thanks for taking over and maintaining this mod ❤️ 

Fix screenshots:
<img width="1595" height="1078" alt="image" src="https://github.com/user-attachments/assets/6b44cbbd-6bf8-47a5-9189-12c10d1bb76a" />

(Newly generated world)
<img width="1874" height="1126" alt="image" src="https://github.com/user-attachments/assets/bf7b6f0f-0a2e-41a7-8162-ef3cb01f8b4d" />

